### PR TITLE
feat(CMD): add new local user store commands to CLI

### DIFF
--- a/cmd/apiclients.go
+++ b/cmd/apiclients.go
@@ -54,8 +54,8 @@ privx-cli api-clients [access flags]
 }
 
 func apiClientList(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-	result, err := store.APIClients()
+	api := userstore.New(curl())
+	result, err := api.APIClients()
 	if err != nil {
 		return err
 	}
@@ -101,9 +101,9 @@ privx-cli api-clients show [access flags] --id API-CLIENT-ID
 }
 
 func apiClientShow(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
+	api := userstore.New(curl())
 
-	result, err := store.APIClient(clientID)
+	result, err := api.APIClient(clientID)
 	if err != nil {
 		return err
 	}
@@ -125,9 +125,9 @@ privx-cli api-clients delete [access flags] --id API-CLIENT-ID
 }
 
 func apiClientDelete(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
+	api := userstore.New(curl())
 
-	err := store.DeleteAPIClient(clientID)
+	err := api.DeleteAPIClient(clientID)
 
 	return err
 }

--- a/cmd/apiclients.go
+++ b/cmd/apiclients.go
@@ -141,6 +141,7 @@ var apiClientUpdateCmd = &cobra.Command{
 	Example: `
 privx-cli users local api-clients update [access flags] --id API-CLIENT-ID JSON-FILE
 	`,
+	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE:         apiClientUpdate,
 }
@@ -148,10 +149,6 @@ privx-cli users local api-clients update [access flags] --id API-CLIENT-ID JSON-
 func apiClientUpdate(cmd *cobra.Command, args []string) error {
 	var apiClient userstore.APIClient
 	api := userstore.New(curl())
-
-	if len(args) != 1 {
-		return errors.New("requires json file as argument")
-	}
 
 	file, err := openJSON(args[0])
 	if err != nil {

--- a/cmd/apiclients.go
+++ b/cmd/apiclients.go
@@ -7,8 +7,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
 	"strings"
 
 	"github.com/SSHcom/privx-sdk-go/api/userstore"
@@ -45,7 +43,7 @@ func init() {
 var apiClientListCmd = &cobra.Command{
 	Use:   "api-clients",
 	Short: "Get API clients",
-	Long:  `Get all API clients from the privx local user store`,
+	Long:  `Get all API clients`,
 	Example: `
 privx-cli api-clients [access flags]
 	`,
@@ -68,7 +66,7 @@ func apiClientList(cmd *cobra.Command, args []string) error {
 var apiClientCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create new API client",
-	Long:  `Create new API client to privX local user store`,
+	Long:  `Create new API client`,
 	Example: `
 privx-cli api-clients create [access flags] --name NAME --roles ROLE-ID,ROLE-ID
 	`,
@@ -92,7 +90,7 @@ func apiClientCreate(cmd *cobra.Command, args []string) error {
 var apiClientShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Get API client by ID",
-	Long:  `Get API client by ID from the privx local user store`,
+	Long:  `Get API client by ID`,
 	Example: `
 privx-cli api-clients show [access flags] --id API-CLIENT-ID
 	`,
@@ -116,7 +114,7 @@ func apiClientShow(cmd *cobra.Command, args []string) error {
 var apiClientDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete API client",
-	Long:  `Delete a API client from the privx local user store`,
+	Long:  `Delete a API client`,
 	Example: `
 privx-cli api-clients delete [access flags] --id API-CLIENT-ID
 	`,
@@ -137,7 +135,7 @@ func apiClientDelete(cmd *cobra.Command, args []string) error {
 var apiClientUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update API client",
-	Long:  `Update an existing API client inside the privx local user store`,
+	Long:  `Update an existing API client`,
 	Example: `
 privx-cli users local api-clients update [access flags] --id API-CLIENT-ID JSON-FILE
 	`,
@@ -150,15 +148,9 @@ func apiClientUpdate(cmd *cobra.Command, args []string) error {
 	var apiClient userstore.APIClient
 	api := userstore.New(curl())
 
-	file, err := openJSON(args[0])
+	err := readJSON(args[0], &apiClient)
 	if err != nil {
 		return err
-	}
-
-	jsonParser := json.NewDecoder(file)
-	err = jsonParser.Decode(&apiClient)
-	if err != nil {
-		return errors.New("json file decoding failed")
 	}
 
 	err = api.UpdateAPIClient(clientID, &apiClient)

--- a/cmd/apiclients.go
+++ b/cmd/apiclients.go
@@ -1,0 +1,170 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/SSHcom/privx-sdk-go/api/userstore"
+	"github.com/spf13/cobra"
+)
+
+var (
+	clientID       string
+	apiClientRoles string
+)
+
+func init() {
+	rootCmd.AddCommand(apiClientListCmd)
+
+	apiClientListCmd.AddCommand(apiClientCreateCmd)
+	apiClientCreateCmd.Flags().StringVar(&name, "name", "", "API client name")
+	apiClientCreateCmd.Flags().StringVar(&apiClientRoles, "roles", "", "list of roles possessed by the API client")
+
+	apiClientListCmd.AddCommand(apiClientShowCmd)
+	apiClientShowCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
+	apiClientShowCmd.MarkFlagRequired("id")
+
+	apiClientListCmd.AddCommand(apiClientDeleteCmd)
+	apiClientDeleteCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
+	apiClientDeleteCmd.MarkFlagRequired("id")
+
+	apiClientListCmd.AddCommand(apiClientUpdateCmd)
+	apiClientUpdateCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
+	apiClientUpdateCmd.MarkFlagRequired("id")
+}
+
+//
+//
+var apiClientListCmd = &cobra.Command{
+	Use:   "api-clients",
+	Short: "Get API clients",
+	Long:  `Get all API clients from the privx local user store`,
+	Example: `
+privx-cli api-clients [access flags]
+	`,
+	SilenceUsage: true,
+	RunE:         apiClientList,
+}
+
+func apiClientList(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+	result, err := store.APIClients()
+	if err != nil {
+		return err
+	}
+
+	return stdout(result)
+}
+
+//
+//
+var apiClientCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create new API client",
+	Long:  `Create new API client to privX local user store`,
+	Example: `
+privx-cli api-clients create [access flags] --name NAME --roles ROLE-ID,ROLE-ID
+	`,
+	SilenceUsage: true,
+	RunE:         apiClientCreate,
+}
+
+func apiClientCreate(cmd *cobra.Command, args []string) error {
+	api := userstore.New(curl())
+
+	id, err := api.CreateAPIClient(name, strings.Split(apiClientRoles, ","))
+	if err != nil {
+		return err
+	}
+
+	return stdout(id)
+}
+
+//
+//
+var apiClientShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Get API client by ID",
+	Long:  `Get API client by ID from the privx local user store`,
+	Example: `
+privx-cli api-clients show [access flags] --id API-CLIENT-ID
+	`,
+	SilenceUsage: true,
+	RunE:         apiClientShow,
+}
+
+func apiClientShow(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	result, err := store.APIClient(clientID)
+	if err != nil {
+		return err
+	}
+
+	return stdout(result)
+}
+
+//
+//
+var apiClientDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete API client",
+	Long:  `Delete a API client from the privx local user store`,
+	Example: `
+privx-cli api-clients delete [access flags] --id API-CLIENT-ID
+	`,
+	SilenceUsage: true,
+	RunE:         apiClientDelete,
+}
+
+func apiClientDelete(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	err := store.DeleteAPIClient(clientID)
+
+	return err
+}
+
+//
+//
+var apiClientUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update API client",
+	Long:  `Update an existing API client inside the privx local user store`,
+	Example: `
+privx-cli users local api-clients update [access flags] --id API-CLIENT-ID JSON-FILE
+	`,
+	SilenceUsage: true,
+	RunE:         apiClientUpdate,
+}
+
+func apiClientUpdate(cmd *cobra.Command, args []string) error {
+	var apiClient userstore.APIClient
+	api := userstore.New(curl())
+
+	if len(args) != 1 {
+		return errors.New("requires json file as argument")
+	}
+
+	file, err := openJSON(args[0])
+	if err != nil {
+		return err
+	}
+
+	jsonParser := json.NewDecoder(file)
+	err = jsonParser.Decode(&apiClient)
+	if err != nil {
+		return errors.New("json file decoding failed")
+	}
+
+	err = api.UpdateAPIClient(clientID, &apiClient)
+
+	return err
+}

--- a/cmd/clients.go
+++ b/cmd/clients.go
@@ -7,9 +7,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-
 	"github.com/SSHcom/privx-sdk-go/api/userstore"
 	"github.com/spf13/cobra"
 )
@@ -41,7 +38,7 @@ func init() {
 var clientListCmd = &cobra.Command{
 	Use:   "clients",
 	Short: "Get trusted clients",
-	Long:  `Get trusted clients from the privx local user store`,
+	Long:  `Get trusted clients`,
 	Example: `
 privx-cli clients [access flags]
 	`,
@@ -65,7 +62,7 @@ func trustedClients(cmd *cobra.Command, args []string) error {
 var clientCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create new trusted-client",
-	Long:  `Create new trusted client to privX local user store`,
+	Long:  `Create new trusted client`,
 	Example: `
 privx-cli clients create [access flags] JSON-FILE
 	`,
@@ -78,15 +75,9 @@ func clientCreate(cmd *cobra.Command, args []string) error {
 	var trustedClient userstore.TrustedClient
 	api := userstore.New(curl())
 
-	file, err := openJSON(args[0])
+	err := readJSON(args[0], &trustedClient)
 	if err != nil {
 		return err
-	}
-
-	jsonParser := json.NewDecoder(file)
-	err = jsonParser.Decode(&trustedClient)
-	if err != nil {
-		return errors.New("json file decoding failed")
 	}
 
 	id, err := api.CreateTrustedClient(trustedClient)
@@ -102,7 +93,7 @@ func clientCreate(cmd *cobra.Command, args []string) error {
 var clientShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Get trusted client by ID",
-	Long:  `Get trusted client by ID from the privx local user store`,
+	Long:  `Get trusted client by ID`,
 	Example: `
 privx-cli clients show [access flags] --id TRUSTED-CLIENT-ID
 	`,
@@ -126,7 +117,7 @@ func clientShow(cmd *cobra.Command, args []string) error {
 var clientDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete trusted client",
-	Long:  `Delete a trusted client from the privx local user store`,
+	Long:  `Delete a trusted client`,
 	Example: `
 privx-cli clients delete [access flags] --id TRUSTED-CLIENT-ID
 	`,
@@ -147,7 +138,7 @@ func clientDelete(cmd *cobra.Command, args []string) error {
 var clientUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update trusted client",
-	Long:  `Update an existing trusted client inside the privx local user store`,
+	Long:  `Update an existing trusted client`,
 	Example: `
 privx-cli clients update [access flags] --id TRUSTED-CLIENT-ID JSON-FILE
 	`,
@@ -160,15 +151,9 @@ func clientUpdate(cmd *cobra.Command, args []string) error {
 	var trustedClient userstore.TrustedClient
 	api := userstore.New(curl())
 
-	file, err := openJSON(args[0])
+	err := readJSON(args[0], &trustedClient)
 	if err != nil {
 		return err
-	}
-
-	jsonParser := json.NewDecoder(file)
-	err = jsonParser.Decode(&trustedClient)
-	if err != nil {
-		return errors.New("json file decoding failed")
 	}
 
 	err = api.UpdateTrustedClient(trustedClientID, &trustedClient)

--- a/cmd/clients.go
+++ b/cmd/clients.go
@@ -1,0 +1,183 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/SSHcom/privx-sdk-go/api/userstore"
+	"github.com/spf13/cobra"
+)
+
+var (
+	trustedClientID string
+)
+
+func init() {
+	rootCmd.AddCommand(clientListCmd)
+
+	clientListCmd.AddCommand(clientCreateCmd)
+
+	clientListCmd.AddCommand(clientShowCmd)
+	clientShowCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
+	clientShowCmd.MarkFlagRequired("id")
+
+	clientListCmd.AddCommand(clientDeleteCmd)
+	clientDeleteCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
+	clientDeleteCmd.MarkFlagRequired("id")
+
+	clientListCmd.AddCommand(clientUpdateCmd)
+	clientUpdateCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
+	clientUpdateCmd.MarkFlagRequired("id")
+}
+
+//
+//
+var clientListCmd = &cobra.Command{
+	Use:   "clients",
+	Short: "Get trusted clients",
+	Long:  `Get trusted clients from the privx local user store`,
+	Example: `
+privx-cli clients [access flags]
+	`,
+	SilenceUsage: true,
+	RunE:         trustedClients,
+}
+
+func trustedClients(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	trustedClients, err := store.TrustedClients()
+	if err != nil {
+		return err
+	}
+
+	return stdout(trustedClients)
+}
+
+//
+//
+var clientCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create new trusted-client",
+	Long:  `Create new trusted client to privX local user store`,
+	Example: `
+privx-cli clients create [access flags] JSON-FILE
+	`,
+	SilenceUsage: true,
+	RunE:         clientCreate,
+}
+
+func clientCreate(cmd *cobra.Command, args []string) error {
+	var trustedClient userstore.TrustedClient
+	api := userstore.New(curl())
+
+	if len(args) != 1 {
+		return errors.New("requires json file as argument")
+	}
+
+	file, err := openJSON(args[0])
+	if err != nil {
+		return err
+	}
+
+	jsonParser := json.NewDecoder(file)
+	err = jsonParser.Decode(&trustedClient)
+	if err != nil {
+		return errors.New("json file decoding failed")
+	}
+
+	id, err := api.CreateTrustedClient(trustedClient)
+	if err != nil {
+		return err
+	}
+
+	return stdout(id)
+}
+
+//
+//
+var clientShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Get trusted client by ID",
+	Long:  `Get trusted client by ID from the privx local user store`,
+	Example: `
+privx-cli clients show [access flags] --id TRUSTED-CLIENT-ID
+	`,
+	SilenceUsage: true,
+	RunE:         clientShow,
+}
+
+func clientShow(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	trustedClient, err := store.TrustedClient(trustedClientID)
+	if err != nil {
+		return err
+	}
+
+	return stdout(trustedClient)
+}
+
+//
+//
+var clientDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete trusted client",
+	Long:  `Delete a trusted client from the privx local user store`,
+	Example: `
+privx-cli clients delete [access flags] --id TRUSTED-CLIENT-ID
+	`,
+	SilenceUsage: true,
+	RunE:         clientDelete,
+}
+
+func clientDelete(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	err := store.DeleteTrustedClient(trustedClientID)
+
+	return err
+}
+
+//
+//
+var clientUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update trusted client",
+	Long:  `Update an existing trusted client inside the privx local user store`,
+	Example: `
+privx-cli clients update [access flags] --id TRUSTED-CLIENT-ID JSON-FILE
+	`,
+	SilenceUsage: true,
+	RunE:         clientUpdate,
+}
+
+func clientUpdate(cmd *cobra.Command, args []string) error {
+	var trustedClient userstore.TrustedClient
+	api := userstore.New(curl())
+
+	if len(args) != 1 {
+		return errors.New("requires json file as argument")
+	}
+
+	file, err := openJSON(args[0])
+	if err != nil {
+		return err
+	}
+
+	jsonParser := json.NewDecoder(file)
+	err = jsonParser.Decode(&trustedClient)
+	if err != nil {
+		return errors.New("json file decoding failed")
+	}
+
+	err = api.UpdateTrustedClient(trustedClientID, &trustedClient)
+
+	return err
+}

--- a/cmd/clients.go
+++ b/cmd/clients.go
@@ -50,9 +50,9 @@ privx-cli clients [access flags]
 }
 
 func trustedClients(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
+	api := userstore.New(curl())
 
-	trustedClients, err := store.TrustedClients()
+	trustedClients, err := api.TrustedClients()
 	if err != nil {
 		return err
 	}
@@ -111,9 +111,9 @@ privx-cli clients show [access flags] --id TRUSTED-CLIENT-ID
 }
 
 func clientShow(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
+	api := userstore.New(curl())
 
-	trustedClient, err := store.TrustedClient(trustedClientID)
+	trustedClient, err := api.TrustedClient(trustedClientID)
 	if err != nil {
 		return err
 	}
@@ -135,9 +135,9 @@ privx-cli clients delete [access flags] --id TRUSTED-CLIENT-ID
 }
 
 func clientDelete(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
+	api := userstore.New(curl())
 
-	err := store.DeleteTrustedClient(trustedClientID)
+	err := api.DeleteTrustedClient(trustedClientID)
 
 	return err
 }

--- a/cmd/clients.go
+++ b/cmd/clients.go
@@ -69,6 +69,7 @@ var clientCreateCmd = &cobra.Command{
 	Example: `
 privx-cli clients create [access flags] JSON-FILE
 	`,
+	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE:         clientCreate,
 }
@@ -76,10 +77,6 @@ privx-cli clients create [access flags] JSON-FILE
 func clientCreate(cmd *cobra.Command, args []string) error {
 	var trustedClient userstore.TrustedClient
 	api := userstore.New(curl())
-
-	if len(args) != 1 {
-		return errors.New("requires json file as argument")
-	}
 
 	file, err := openJSON(args[0])
 	if err != nil {
@@ -154,6 +151,7 @@ var clientUpdateCmd = &cobra.Command{
 	Example: `
 privx-cli clients update [access flags] --id TRUSTED-CLIENT-ID JSON-FILE
 	`,
+	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE:         clientUpdate,
 }
@@ -161,10 +159,6 @@ privx-cli clients update [access flags] --id TRUSTED-CLIENT-ID JSON-FILE
 func clientUpdate(cmd *cobra.Command, args []string) error {
 	var trustedClient userstore.TrustedClient
 	api := userstore.New(curl())
-
-	if len(args) != 1 {
-		return errors.New("requires json file as argument")
-	}
 
 	file, err := openJSON(args[0])
 	if err != nil {

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -33,8 +33,8 @@ func init() {
 //
 var tagListCmd = &cobra.Command{
 	Use:   "tags",
-	Short: "user/host tags",
-	Long:  `get privx user or host tags`,
+	Short: "User | Host tags",
+	Long:  `Get privx user or host tags`,
 	Example: `
 privx-cli tags [access flags] --type user
 privx-cli tags [access flags] --type host --sortdir DESC

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -58,9 +58,9 @@ func tagList(cmd *cobra.Command, args []string) error {
 }
 
 func userTags() error {
-	store := userstore.New(curl())
+	api := userstore.New(curl())
 
-	tags, err := store.LocalUserTags(offset, limit, strings.ToUpper(sortdir), query)
+	tags, err := api.LocalUserTags(offset, limit, strings.ToUpper(sortdir), query)
 	if err != nil {
 		return err
 	}
@@ -69,9 +69,9 @@ func userTags() error {
 }
 
 func hostTags() error {
-	store := hoststore.New(curl())
+	api := hoststore.New(curl())
 
-	tags, err := store.HostTags(offset, limit, strings.ToUpper(sortdir), query)
+	tags, err := api.HostTags(offset, limit, strings.ToUpper(sortdir), query)
 	if err != nil {
 		return err
 	}

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/SSHcom/privx-sdk-go/api/hoststore"
+	"github.com/SSHcom/privx-sdk-go/api/userstore"
+	"github.com/spf13/cobra"
+)
+
+var (
+	tagType string
+)
+
+func init() {
+	rootCmd.AddCommand(tagListCmd)
+	tagListCmd.Flags().IntVar(&offset, "offset", 0, "where to start fetching the items")
+	tagListCmd.Flags().IntVar(&limit, "limit", 50, "number of items to return")
+	tagListCmd.Flags().StringVar(&query, "query", "", "query string matches the tags")
+	tagListCmd.Flags().StringVar(&sortdir, "sortdir", "", "sort direction, ASC or DESC (default ASC)")
+	tagListCmd.Flags().StringVar(&tagType, "type", "", "choose the tag type, user or host")
+	tagListCmd.MarkFlagRequired("type")
+}
+
+//
+//
+var tagListCmd = &cobra.Command{
+	Use:   "tags",
+	Short: "user/host tags",
+	Long:  `get privx user or host tags`,
+	Example: `
+privx-cli tags [access flags] --type user
+privx-cli tags [access flags] --type host --sortdir DESC
+privx-cli tags [access flags] --type host --query TAG
+privx-cli tags [access flags] --type user --offset OFFSET --limit LIMIT
+	`,
+	SilenceUsage: true,
+	RunE:         tagList,
+}
+
+func tagList(cmd *cobra.Command, args []string) error {
+	if tagType == "user" {
+		userTags()
+	} else if tagType == "host" {
+		hostTags()
+	} else {
+		return fmt.Errorf("tag type does not exist: %s", tagType)
+	}
+
+	return nil
+}
+
+func userTags() error {
+	store := userstore.New(curl())
+
+	tags, err := store.LocalUserTags(offset, limit, strings.ToUpper(sortdir), query)
+	if err != nil {
+		return err
+	}
+
+	return stdout(tags)
+}
+
+func hostTags() error {
+	store := hoststore.New(curl())
+
+	tags, err := store.HostTags(offset, limit, strings.ToUpper(sortdir), query)
+	if err != nil {
+		return err
+	}
+
+	return stdout(tags)
+}

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -7,7 +7,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
+	"os"
 	"strings"
 
 	"github.com/SSHcom/privx-sdk-go/api/rolestore"
@@ -16,19 +18,101 @@ import (
 )
 
 var (
-	userQuery      []string
-	userID         string
-	userRoleGrant  []string
-	userRoleRevoke []string
-	offset         string
-	limit          string
-	userName       string
+	userID          string
+	trustedClientID string
+	userName        string
+	password        string
+	clientID        string
+	query           string
+	apiClientRoles  string
+	offset          int
+	limit           int
+	userQuery       []string
+	userRoleGrant   []string
+	userRoleRevoke  []string
 )
 
 func init() {
 	rootCmd.AddCommand(usersCmd)
 	usersCmd.Flags().StringArrayVarP(&userQuery, "query", "q", []string{}, "query PrivX users with keyword")
 
+	//
+	// local user commands
+	usersCmd.AddCommand(localUsersCmd)
+	localUsersCmd.Flags().IntVar(&offset, "offset", 0, "where to start fetching the items")
+	localUsersCmd.Flags().IntVar(&limit, "limit", 50, "number of items to return")
+	localUsersCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+	localUsersCmd.Flags().StringVar(&userName, "username", "", "unique user name")
+
+	localUsersCmd.AddCommand(localUserCmd)
+	localUserCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+
+	localUserCmd.AddCommand(createLocalUserCmd)
+
+	localUserCmd.AddCommand(updateLocalUserCmd)
+	updateLocalUserCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+	updateLocalUserCmd.MarkFlagRequired("uid")
+
+	localUserCmd.AddCommand(deleteLocalUserCmd)
+	deleteLocalUserCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+	deleteLocalUserCmd.MarkFlagRequired("uid")
+
+	localUserCmd.AddCommand(updateLocalUserPasswordCmd)
+	updateLocalUserPasswordCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+	updateLocalUserPasswordCmd.Flags().StringVar(&password, "password", "", "new password for local user")
+	updateLocalUserPasswordCmd.MarkFlagRequired("uid")
+	updateLocalUserPasswordCmd.MarkFlagRequired("password")
+
+	localUserCmd.AddCommand(localUserTagsCmd)
+	localUserTagsCmd.Flags().IntVar(&offset, "offset", 0, "where to start fetching the items")
+	localUserTagsCmd.Flags().IntVar(&limit, "limit", 50, "number of items to return")
+	localUserTagsCmd.Flags().StringVar(&query, "query", "", "query string matches the tags")
+	localUserTagsCmd.Flags().StringVar(&sortdir, "sortdir", "", "sort direction, ASC or DESC (default ASC)")
+
+	//
+	// trusted clients commands
+	localUsersCmd.AddCommand(trustedClientsCmd)
+
+	trustedClientsCmd.AddCommand(createTrustedClientCmd)
+
+	trustedClientsCmd.AddCommand(trustedClientCmd)
+	trustedClientCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
+	trustedClientCmd.MarkFlagRequired("id")
+
+	trustedClientsCmd.AddCommand(deleteTrustedClientCmd)
+	deleteTrustedClientCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
+	deleteTrustedClientCmd.MarkFlagRequired("id")
+
+	trustedClientsCmd.AddCommand(updateTrustedClientCmd)
+	updateTrustedClientCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
+	updateTrustedClientCmd.MarkFlagRequired("id")
+
+	//
+	// extender clients commands
+	localUsersCmd.AddCommand(extenderClientsCmd)
+
+	//
+	// API clients commands
+	localUsersCmd.AddCommand(apiClientsCmd)
+
+	apiClientsCmd.AddCommand(createAPIClientCmd)
+	createAPIClientCmd.Flags().StringVar(&name, "name", "", "API client name")
+	createAPIClientCmd.Flags().StringVar(&apiClientRoles, "roles", "", "list of roles possessed by the API client")
+
+	apiClientsCmd.AddCommand(apiClientCmd)
+	apiClientCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
+	apiClientCmd.MarkFlagRequired("id")
+
+	apiClientsCmd.AddCommand(deleteAPIClientCmd)
+	deleteAPIClientCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
+	deleteAPIClientCmd.MarkFlagRequired("id")
+
+	apiClientsCmd.AddCommand(updateAPIClientCmd)
+	updateAPIClientCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
+	updateAPIClientCmd.MarkFlagRequired("id")
+
+	//
+	// users commands
 	usersCmd.AddCommand(usersInfoCmd)
 
 	usersCmd.AddCommand(usersRolesCmd)
@@ -37,11 +121,508 @@ func init() {
 	usersRolesCmd.Flags().StringArrayVar(&userRoleRevoke, "revoke", []string{}, "revoke role from user, requires role unique id.")
 	usersRolesCmd.MarkFlagRequired("uid")
 
-	usersCmd.AddCommand(localusersCmd)
-	localusersCmd.Flags().StringVar(&offset, "offset", "", "offset")
-	localusersCmd.Flags().StringVar(&limit, "limit", "", "limit")
-	localusersCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
-	localusersCmd.Flags().StringVar(&userName, "name", "", "unique user name")
+}
+
+//
+//
+var localUsersCmd = &cobra.Command{
+	Use:   "local",
+	Short: "local users",
+	Long:  `get information about privx local users`,
+	Example: `
+privx-cli users local [access flags] COMMANDS
+privx-cli users local [access flags] --uid UID
+privx-cli users local [access flags] --username USERNAME
+privx-cli users local [access flags] --offset OFFSET --limit LIMIT
+	`,
+	SilenceUsage: true,
+	RunE:         localUsers,
+}
+
+func localUsers(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	users, err := store.LocalUsers(offset, limit, userID, userName)
+	if err != nil {
+		return err
+	}
+
+	return stdout(users)
+}
+
+//
+//
+var createLocalUserCmd = &cobra.Command{
+	Use:   "create",
+	Short: "create new local user",
+	Long:  `create new local user to privx local user store`,
+	Example: `
+privx-cli users local user create [access flags] JSON-FILE
+	`,
+	SilenceUsage: true,
+	RunE:         createLocalUser,
+}
+
+func createLocalUser(cmd *cobra.Command, args []string) error {
+	var newUser userstore.LocalUser
+	api := userstore.New(curl())
+
+	if len(args) != 1 {
+		return errors.New("requires json file as argument")
+	}
+
+	file, err := openJSON(args[0])
+	if err != nil {
+		return err
+	}
+
+	jsonParser := json.NewDecoder(file)
+	err = jsonParser.Decode(&newUser)
+	if err != nil {
+		return errors.New("json file decoding failed")
+	}
+
+	uid, err := api.CreateLocalUser(newUser)
+	if err != nil {
+		return err
+	}
+
+	return stdout(uid)
+}
+
+//
+//
+var localUserCmd = &cobra.Command{
+	Use:   "user",
+	Short: "Get a local user",
+	Long:  `Get a local user by user ID`,
+	Example: `
+privx-cli users local user [access flags] --uid UID
+	`,
+	SilenceUsage: true,
+	RunE:         localUser,
+}
+
+func localUser(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	user, err := store.LocalUser(userID)
+	if err != nil {
+		return err
+	}
+
+	return stdout(user)
+}
+
+//
+//
+var updateLocalUserCmd = &cobra.Command{
+	Use:   "update",
+	Short: "update local user",
+	Long:  `update a local user inside the privx local user store`,
+	Example: `
+privx-cli users local user update [access flags] JSON-FILE --uid UID
+	`,
+	SilenceUsage: true,
+	RunE:         updateLocalUser,
+}
+
+func updateLocalUser(cmd *cobra.Command, args []string) error {
+	var updateUser userstore.LocalUser
+	api := userstore.New(curl())
+
+	if len(args) != 1 {
+		return errors.New("requires json file as argument")
+	}
+
+	file, err := openJSON(args[0])
+	if err != nil {
+		return err
+	}
+
+	jsonParser := json.NewDecoder(file)
+	err = jsonParser.Decode(&updateUser)
+	if err != nil {
+		return errors.New("json file decoding failed")
+	}
+
+	err = api.UpdateLocalUser(userID, &updateUser)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+//
+//
+var deleteLocalUserCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "delete local user",
+	Long:  `delete a local user from the privx local user store`,
+	Example: `
+privx-cli users local user delete [access flags] --uid UID
+	`,
+	SilenceUsage: true,
+	RunE:         deleteLocalUser,
+}
+
+func deleteLocalUser(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	err := store.DeleteLocalUser(userID)
+
+	return err
+}
+
+//
+//
+var updateLocalUserPasswordCmd = &cobra.Command{
+	Use:   "update-password",
+	Short: "update local user password",
+	Long:  `update a local users password inside the privx local user store`,
+	Example: `
+privx-cli users local user update-password [access flags] --uid UID --password NEW-PASSWORD
+	`,
+	SilenceUsage: true,
+	RunE:         updateLocalUserPassword,
+}
+
+func updateLocalUserPassword(cmd *cobra.Command, args []string) error {
+	newPassword := userstore.Password{
+		Password: password,
+	}
+	api := userstore.New(curl())
+
+	err := api.UpdateLocalUserPassword(userID, &newPassword)
+
+	return err
+}
+
+//
+//
+var localUserTagsCmd = &cobra.Command{
+	Use:   "tags",
+	Short: "local user tags",
+	Long:  `get privx local user tags`,
+	Example: `
+privx-cli users local tags [access flags]
+privx-cli users local tags [access flags] --sortdir DESC
+privx-cli users local tags [access flags] --query TAG
+privx-cli users local tags [access flags] --offset OFFSET --limit LIMIT
+	`,
+	SilenceUsage: true,
+	RunE:         localUserTags,
+}
+
+func localUserTags(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	tags, err := store.LocalUserTags(offset, limit, strings.ToUpper(sortdir), query)
+	if err != nil {
+		return err
+	}
+
+	return stdout(tags)
+}
+
+//
+//
+var trustedClientsCmd = &cobra.Command{
+	Use:   "trusted-clients",
+	Short: "get trusted clients",
+	Long:  `get trusted clients from the privx local user store`,
+	Example: `
+privx-cli users trusted-clients [access flags]
+	`,
+	SilenceUsage: true,
+	RunE:         trustedClients,
+}
+
+func trustedClients(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	trustedClients, err := store.TrustedClients()
+	if err != nil {
+		return err
+	}
+
+	return stdout(trustedClients)
+}
+
+//
+//
+var createTrustedClientCmd = &cobra.Command{
+	Use:   "create",
+	Short: "create new trusted-client",
+	Long:  `create new trusted client to privX local user store`,
+	Example: `
+privx-cli users local trusted-clients create [access flags] JSON-FILE
+	`,
+	SilenceUsage: true,
+	RunE:         createTrustedClient,
+}
+
+func createTrustedClient(cmd *cobra.Command, args []string) error {
+	var trustedClient userstore.TrustedClient
+	api := userstore.New(curl())
+
+	if len(args) != 1 {
+		return errors.New("requires json file as argument")
+	}
+
+	file, err := openJSON(args[0])
+	if err != nil {
+		return err
+	}
+
+	jsonParser := json.NewDecoder(file)
+	err = jsonParser.Decode(&trustedClient)
+	if err != nil {
+		return errors.New("json file decoding failed")
+	}
+
+	id, err := api.CreateTrustedClient(trustedClient)
+	if err != nil {
+		return err
+	}
+
+	return stdout(id)
+}
+
+//
+//
+var trustedClientCmd = &cobra.Command{
+	Use:   "client",
+	Short: "get trusted client by ID",
+	Long:  `get trusted client by ID from the privx local user store`,
+	Example: `
+privx-cli users trusted-clients client [access flags] --id TRUSTED-CLIENT-ID
+	`,
+	SilenceUsage: true,
+	RunE:         trustedClient,
+}
+
+func trustedClient(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	trustedClient, err := store.TrustedClient(trustedClientID)
+	if err != nil {
+		return err
+	}
+
+	return stdout(trustedClient)
+}
+
+//
+//
+var deleteTrustedClientCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "delete trusted client",
+	Long:  `delete a trusted client from the privx local user store`,
+	Example: `
+privx-cli users local trusted-clients delete [access flags] --id TRUSTED-CLIENT-ID
+	`,
+	SilenceUsage: true,
+	RunE:         deleteTrustedClient,
+}
+
+func deleteTrustedClient(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	err := store.DeleteTrustedClient(trustedClientID)
+
+	return err
+}
+
+//
+//
+var updateTrustedClientCmd = &cobra.Command{
+	Use:   "update",
+	Short: "update trusted client",
+	Long:  `update an existing trusted client inside the privx local user store`,
+	Example: `
+privx-cli users local trusted-clients update [access flags] --id TRUSTED-CLIENT-ID JSON-FILE
+	`,
+	SilenceUsage: true,
+	RunE:         updateTrustedClient,
+}
+
+func updateTrustedClient(cmd *cobra.Command, args []string) error {
+	var trustedClient userstore.TrustedClient
+	api := userstore.New(curl())
+
+	if len(args) != 1 {
+		return errors.New("requires json file as argument")
+	}
+
+	file, err := openJSON(args[0])
+	if err != nil {
+		return err
+	}
+
+	jsonParser := json.NewDecoder(file)
+	err = jsonParser.Decode(&trustedClient)
+	if err != nil {
+		return errors.New("json file decoding failed")
+	}
+
+	err = api.UpdateTrustedClient(trustedClientID, &trustedClient)
+
+	return err
+}
+
+//
+//
+var extenderClientsCmd = &cobra.Command{
+	Use:   "extender-clients",
+	Short: "get extender clients",
+	Long:  `get extender clients from the privx local user store`,
+	Example: `
+privx-cli users local extender-clients [access flags]
+	`,
+	SilenceUsage: true,
+	RunE:         extenderClients,
+}
+
+func extenderClients(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	extenderClients, err := store.TrustedClients()
+	if err != nil {
+		return err
+	}
+
+	return stdout(extenderClients)
+}
+
+//
+//
+var apiClientsCmd = &cobra.Command{
+	Use:   "api-clients",
+	Short: "get API clients",
+	Long:  `get all API clients from the privx local user store`,
+	Example: `
+privx-cli users local api-clients [access flags]
+	`,
+	SilenceUsage: true,
+	RunE:         apiClients,
+}
+
+func apiClients(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+	result, err := store.APIClients()
+	if err != nil {
+		return err
+	}
+
+	return stdout(result)
+}
+
+//
+//
+var createAPIClientCmd = &cobra.Command{
+	Use:   "create",
+	Short: "create new API client",
+	Long:  `create new API client to privX local user store`,
+	Example: `
+privx-cli users local api-clients create [access flags] --name NAME --roles ROLE-ID,ROLE-ID
+	`,
+	SilenceUsage: true,
+	RunE:         createAPIClient,
+}
+
+func createAPIClient(cmd *cobra.Command, args []string) error {
+	api := userstore.New(curl())
+
+	id, err := api.CreateAPIClient(name, strings.Split(apiClientRoles, ","))
+	if err != nil {
+		return err
+	}
+
+	return stdout(id)
+}
+
+//
+//
+var apiClientCmd = &cobra.Command{
+	Use:   "client",
+	Short: "get API client",
+	Long:  `get API client by ID from the privx local user store`,
+	Example: `
+privx-cli users local api-clients client [access flags] --id API-CLIENT-ID
+	`,
+	SilenceUsage: true,
+	RunE:         apiClient,
+}
+
+func apiClient(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	result, err := store.APIClient(clientID)
+	if err != nil {
+		return err
+	}
+
+	return stdout(result)
+}
+
+//
+//
+var deleteAPIClientCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "delete API client",
+	Long:  `delete a API client from the privx local user store`,
+	Example: `
+privx-cli users local api-clients delete [access flags] --id API-CLIENT-ID
+	`,
+	SilenceUsage: true,
+	RunE:         deleteAPIClient,
+}
+
+func deleteAPIClient(cmd *cobra.Command, args []string) error {
+	store := userstore.New(curl())
+
+	err := store.DeleteAPIClient(clientID)
+
+	return err
+}
+
+//
+//
+var updateAPIClientCmd = &cobra.Command{
+	Use:   "update",
+	Short: "update API client",
+	Long:  `update an existing API client inside the privx local user store`,
+	Example: `
+privx-cli users local api-clients update [access flags] --id API-CLIENT-ID JSON-FILE
+	`,
+	SilenceUsage: true,
+	RunE:         updateAPIClient,
+}
+
+func updateAPIClient(cmd *cobra.Command, args []string) error {
+	var apiClient userstore.APIClient
+	api := userstore.New(curl())
+
+	if len(args) != 1 {
+		return errors.New("requires json file as argument")
+	}
+
+	file, err := openJSON(args[0])
+	if err != nil {
+		return err
+	}
+
+	jsonParser := json.NewDecoder(file)
+	err = jsonParser.Decode(&apiClient)
+	if err != nil {
+		return errors.New("json file decoding failed")
+	}
+
+	err = api.UpdateAPIClient(clientID, &apiClient)
+
+	return err
 }
 
 //
@@ -118,14 +699,14 @@ func userRoles(cmd *cobra.Command, args []string) error {
 	store := rolestore.New(curl())
 
 	for _, role := range userRoleGrant {
-		err := store.AddUserRole(userID, role)
+		err := store.GrantUserRole(userID, role)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, role := range userRoleRevoke {
-		err := store.RemoveUserRole(userID, role)
+		err := store.RevokeUserRole(userID, role)
 		if err != nil {
 			return err
 		}
@@ -138,29 +719,11 @@ func userRoles(cmd *cobra.Command, args []string) error {
 	return stdout(roles)
 }
 
-//
-//
-var localusersCmd = &cobra.Command{
-	Use:   "local",
-	Short: "local users",
-	Long:  `Get information about PrivX local users`,
-	Example: `
-privx-cli users local [access flags]
-privx-cli users local [access flags] --uid UID
-privx-cli users local [access flags] --name USERNAME
-privx-cli users local [access flags] --offset OFFSET --limit LIMIT
-	`,
-	SilenceUsage: true,
-	RunE:         local,
-}
-
-func local(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	user, err := store.LocalUsers(offset, limit, userID, userName)
+func openJSON(name string) (*os.File, error) {
+	file, err := os.Open(name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return stdout(user)
+	return file, err
 }

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -145,9 +145,9 @@ privx-cli users delete [access flags] --uid UID
 }
 
 func userDelete(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
+	api := userstore.New(curl())
 
-	err := store.DeleteLocalUser(userID)
+	err := api.DeleteLocalUser(userID)
 
 	return err
 }
@@ -190,8 +190,8 @@ privx-cli users [access flags]
 }
 
 func userList(cmd *cobra.Command, args []string) error {
-	store := rolestore.New(curl())
-	users, err := store.SearchUsers(strings.Join(userQuery, ","), "")
+	api := rolestore.New(curl())
+	users, err := api.SearchUsers(strings.Join(userQuery, ","), "")
 	if err != nil {
 		return err
 	}
@@ -214,11 +214,11 @@ privx-cli users show [access flags] UID ...
 }
 
 func userShow(cmd *cobra.Command, args []string) error {
-	store := rolestore.New(curl())
+	api := rolestore.New(curl())
 	users := []rolestore.User{}
 
 	for _, uid := range args {
-		user, err := store.User(uid)
+		user, err := api.User(uid)
 		if err != nil {
 			return err
 		}
@@ -244,23 +244,23 @@ privx-cli users roles [access flags] --uid UID --revoke role-uid
 }
 
 func userRoles(cmd *cobra.Command, args []string) error {
-	store := rolestore.New(curl())
+	api := rolestore.New(curl())
 
 	for _, role := range userRoleGrant {
-		err := store.GrantUserRole(userID, role)
+		err := api.GrantUserRole(userID, role)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, role := range userRoleRevoke {
-		err := store.RevokeUserRole(userID, role)
+		err := api.RevokeUserRole(userID, role)
 		if err != nil {
 			return err
 		}
 	}
 
-	roles, err := store.UserRoles(userID)
+	roles, err := api.UserRoles(userID)
 	if err != nil {
 		return err
 	}

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 SSH Communications Security Inc.
+// Copyright (c) 2021 SSH Communications Security Inc.
 //
 // All rights reserved.
 //
@@ -18,152 +18,61 @@ import (
 )
 
 var (
-	userID          string
-	trustedClientID string
-	userName        string
-	password        string
-	clientID        string
-	query           string
-	apiClientRoles  string
-	offset          int
-	limit           int
-	userQuery       []string
-	userRoleGrant   []string
-	userRoleRevoke  []string
+	userID         string
+	password       string
+	query          string
+	offset         int
+	limit          int
+	userQuery      []string
+	userRoleGrant  []string
+	userRoleRevoke []string
 )
 
 func init() {
-	rootCmd.AddCommand(usersCmd)
-	usersCmd.Flags().StringArrayVarP(&userQuery, "query", "q", []string{}, "query PrivX users with keyword")
+	rootCmd.AddCommand(userListCmd)
+	userListCmd.Flags().StringArrayVarP(&userQuery, "query", "q", []string{}, "query PrivX users with keyword")
 
-	//
-	// local user commands
-	usersCmd.AddCommand(localUsersCmd)
-	localUsersCmd.Flags().IntVar(&offset, "offset", 0, "where to start fetching the items")
-	localUsersCmd.Flags().IntVar(&limit, "limit", 50, "number of items to return")
-	localUsersCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
-	localUsersCmd.Flags().StringVar(&userName, "username", "", "unique user name")
+	userListCmd.AddCommand(userCreateCmd)
 
-	localUsersCmd.AddCommand(localUserCmd)
-	localUserCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+	userListCmd.AddCommand(userUpdateCmd)
+	userUpdateCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+	userUpdateCmd.MarkFlagRequired("uid")
 
-	localUserCmd.AddCommand(createLocalUserCmd)
+	userListCmd.AddCommand(userDeleteCmd)
+	userDeleteCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+	userDeleteCmd.MarkFlagRequired("uid")
 
-	localUserCmd.AddCommand(updateLocalUserCmd)
-	updateLocalUserCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
-	updateLocalUserCmd.MarkFlagRequired("uid")
-
-	localUserCmd.AddCommand(deleteLocalUserCmd)
-	deleteLocalUserCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
-	deleteLocalUserCmd.MarkFlagRequired("uid")
-
-	localUserCmd.AddCommand(updateLocalUserPasswordCmd)
-	updateLocalUserPasswordCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
-	updateLocalUserPasswordCmd.Flags().StringVar(&password, "password", "", "new password for local user")
-	updateLocalUserPasswordCmd.MarkFlagRequired("uid")
-	updateLocalUserPasswordCmd.MarkFlagRequired("password")
-
-	localUserCmd.AddCommand(localUserTagsCmd)
-	localUserTagsCmd.Flags().IntVar(&offset, "offset", 0, "where to start fetching the items")
-	localUserTagsCmd.Flags().IntVar(&limit, "limit", 50, "number of items to return")
-	localUserTagsCmd.Flags().StringVar(&query, "query", "", "query string matches the tags")
-	localUserTagsCmd.Flags().StringVar(&sortdir, "sortdir", "", "sort direction, ASC or DESC (default ASC)")
-
-	//
-	// trusted clients commands
-	localUsersCmd.AddCommand(trustedClientsCmd)
-
-	trustedClientsCmd.AddCommand(createTrustedClientCmd)
-
-	trustedClientsCmd.AddCommand(trustedClientCmd)
-	trustedClientCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
-	trustedClientCmd.MarkFlagRequired("id")
-
-	trustedClientsCmd.AddCommand(deleteTrustedClientCmd)
-	deleteTrustedClientCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
-	deleteTrustedClientCmd.MarkFlagRequired("id")
-
-	trustedClientsCmd.AddCommand(updateTrustedClientCmd)
-	updateTrustedClientCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
-	updateTrustedClientCmd.MarkFlagRequired("id")
-
-	//
-	// extender clients commands
-	localUsersCmd.AddCommand(extenderClientsCmd)
-
-	//
-	// API clients commands
-	localUsersCmd.AddCommand(apiClientsCmd)
-
-	apiClientsCmd.AddCommand(createAPIClientCmd)
-	createAPIClientCmd.Flags().StringVar(&name, "name", "", "API client name")
-	createAPIClientCmd.Flags().StringVar(&apiClientRoles, "roles", "", "list of roles possessed by the API client")
-
-	apiClientsCmd.AddCommand(apiClientCmd)
-	apiClientCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
-	apiClientCmd.MarkFlagRequired("id")
-
-	apiClientsCmd.AddCommand(deleteAPIClientCmd)
-	deleteAPIClientCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
-	deleteAPIClientCmd.MarkFlagRequired("id")
-
-	apiClientsCmd.AddCommand(updateAPIClientCmd)
-	updateAPIClientCmd.Flags().StringVar(&clientID, "id", "", "unique API client id")
-	updateAPIClientCmd.MarkFlagRequired("id")
+	userListCmd.AddCommand(userUpdatePasswordCmd)
+	userUpdatePasswordCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
+	userUpdatePasswordCmd.Flags().StringVar(&password, "password", "", "new password for local user")
+	userUpdatePasswordCmd.MarkFlagRequired("uid")
+	userUpdatePasswordCmd.MarkFlagRequired("password")
 
 	//
 	// users commands
-	usersCmd.AddCommand(usersInfoCmd)
+	userListCmd.AddCommand(userShowCmd)
 
-	usersCmd.AddCommand(usersRolesCmd)
+	userListCmd.AddCommand(usersRolesCmd)
 	usersRolesCmd.Flags().StringVar(&userID, "uid", "", "user unique id")
 	usersRolesCmd.Flags().StringArrayVar(&userRoleGrant, "grant", []string{}, "grant role to user, requires role unique id.")
 	usersRolesCmd.Flags().StringArrayVar(&userRoleRevoke, "revoke", []string{}, "revoke role from user, requires role unique id.")
 	usersRolesCmd.MarkFlagRequired("uid")
-
 }
 
 //
 //
-var localUsersCmd = &cobra.Command{
-	Use:   "local",
-	Short: "local users",
-	Long:  `get information about privx local users`,
-	Example: `
-privx-cli users local [access flags] COMMANDS
-privx-cli users local [access flags] --uid UID
-privx-cli users local [access flags] --username USERNAME
-privx-cli users local [access flags] --offset OFFSET --limit LIMIT
-	`,
-	SilenceUsage: true,
-	RunE:         localUsers,
-}
-
-func localUsers(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	users, err := store.LocalUsers(offset, limit, userID, userName)
-	if err != nil {
-		return err
-	}
-
-	return stdout(users)
-}
-
-//
-//
-var createLocalUserCmd = &cobra.Command{
+var userCreateCmd = &cobra.Command{
 	Use:   "create",
-	Short: "create new local user",
-	Long:  `create new local user to privx local user store`,
+	Short: "Create new local user",
+	Long:  `Create new local user to privx local user store`,
 	Example: `
-privx-cli users local user create [access flags] JSON-FILE
+privx-cli users create [access flags] JSON-FILE
 	`,
 	SilenceUsage: true,
-	RunE:         createLocalUser,
+	RunE:         userCreate,
 }
 
-func createLocalUser(cmd *cobra.Command, args []string) error {
+func userCreate(cmd *cobra.Command, args []string) error {
 	var newUser userstore.LocalUser
 	api := userstore.New(curl())
 
@@ -192,42 +101,18 @@ func createLocalUser(cmd *cobra.Command, args []string) error {
 
 //
 //
-var localUserCmd = &cobra.Command{
-	Use:   "user",
-	Short: "Get a local user",
-	Long:  `Get a local user by user ID`,
-	Example: `
-privx-cli users local user [access flags] --uid UID
-	`,
-	SilenceUsage: true,
-	RunE:         localUser,
-}
-
-func localUser(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	user, err := store.LocalUser(userID)
-	if err != nil {
-		return err
-	}
-
-	return stdout(user)
-}
-
-//
-//
-var updateLocalUserCmd = &cobra.Command{
+var userUpdateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "update local user",
-	Long:  `update a local user inside the privx local user store`,
+	Short: "Update local user",
+	Long:  `Update a local user inside the privx local user store`,
 	Example: `
-privx-cli users local user update [access flags] JSON-FILE --uid UID
+privx-cli users update [access flags] JSON-FILE --uid UID
 	`,
 	SilenceUsage: true,
-	RunE:         updateLocalUser,
+	RunE:         userUpdate,
 }
 
-func updateLocalUser(cmd *cobra.Command, args []string) error {
+func userUpdate(cmd *cobra.Command, args []string) error {
 	var updateUser userstore.LocalUser
 	api := userstore.New(curl())
 
@@ -256,18 +141,18 @@ func updateLocalUser(cmd *cobra.Command, args []string) error {
 
 //
 //
-var deleteLocalUserCmd = &cobra.Command{
+var userDeleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "delete local user",
-	Long:  `delete a local user from the privx local user store`,
+	Short: "Delete local user",
+	Long:  `Delete a local user from the privx local user store`,
 	Example: `
-privx-cli users local user delete [access flags] --uid UID
+privx-cli users delete [access flags] --uid UID
 	`,
 	SilenceUsage: true,
-	RunE:         deleteLocalUser,
+	RunE:         userDelete,
 }
 
-func deleteLocalUser(cmd *cobra.Command, args []string) error {
+func userDelete(cmd *cobra.Command, args []string) error {
 	store := userstore.New(curl())
 
 	err := store.DeleteLocalUser(userID)
@@ -277,18 +162,18 @@ func deleteLocalUser(cmd *cobra.Command, args []string) error {
 
 //
 //
-var updateLocalUserPasswordCmd = &cobra.Command{
+var userUpdatePasswordCmd = &cobra.Command{
 	Use:   "update-password",
-	Short: "update local user password",
-	Long:  `update a local users password inside the privx local user store`,
+	Short: "Update local user password",
+	Long:  `Update a local users password inside the privx local user store`,
 	Example: `
-privx-cli users local user update-password [access flags] --uid UID --password NEW-PASSWORD
+privx-cli users update-password [access flags] --uid UID --password NEW-PASSWORD
 	`,
 	SilenceUsage: true,
-	RunE:         updateLocalUserPassword,
+	RunE:         userUpdatePassword,
 }
 
-func updateLocalUserPassword(cmd *cobra.Command, args []string) error {
+func userUpdatePassword(cmd *cobra.Command, args []string) error {
 	newPassword := userstore.Password{
 		Password: password,
 	}
@@ -301,333 +186,7 @@ func updateLocalUserPassword(cmd *cobra.Command, args []string) error {
 
 //
 //
-var localUserTagsCmd = &cobra.Command{
-	Use:   "tags",
-	Short: "local user tags",
-	Long:  `get privx local user tags`,
-	Example: `
-privx-cli users local tags [access flags]
-privx-cli users local tags [access flags] --sortdir DESC
-privx-cli users local tags [access flags] --query TAG
-privx-cli users local tags [access flags] --offset OFFSET --limit LIMIT
-	`,
-	SilenceUsage: true,
-	RunE:         localUserTags,
-}
-
-func localUserTags(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	tags, err := store.LocalUserTags(offset, limit, strings.ToUpper(sortdir), query)
-	if err != nil {
-		return err
-	}
-
-	return stdout(tags)
-}
-
-//
-//
-var trustedClientsCmd = &cobra.Command{
-	Use:   "trusted-clients",
-	Short: "get trusted clients",
-	Long:  `get trusted clients from the privx local user store`,
-	Example: `
-privx-cli users trusted-clients [access flags]
-	`,
-	SilenceUsage: true,
-	RunE:         trustedClients,
-}
-
-func trustedClients(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	trustedClients, err := store.TrustedClients()
-	if err != nil {
-		return err
-	}
-
-	return stdout(trustedClients)
-}
-
-//
-//
-var createTrustedClientCmd = &cobra.Command{
-	Use:   "create",
-	Short: "create new trusted-client",
-	Long:  `create new trusted client to privX local user store`,
-	Example: `
-privx-cli users local trusted-clients create [access flags] JSON-FILE
-	`,
-	SilenceUsage: true,
-	RunE:         createTrustedClient,
-}
-
-func createTrustedClient(cmd *cobra.Command, args []string) error {
-	var trustedClient userstore.TrustedClient
-	api := userstore.New(curl())
-
-	if len(args) != 1 {
-		return errors.New("requires json file as argument")
-	}
-
-	file, err := openJSON(args[0])
-	if err != nil {
-		return err
-	}
-
-	jsonParser := json.NewDecoder(file)
-	err = jsonParser.Decode(&trustedClient)
-	if err != nil {
-		return errors.New("json file decoding failed")
-	}
-
-	id, err := api.CreateTrustedClient(trustedClient)
-	if err != nil {
-		return err
-	}
-
-	return stdout(id)
-}
-
-//
-//
-var trustedClientCmd = &cobra.Command{
-	Use:   "client",
-	Short: "get trusted client by ID",
-	Long:  `get trusted client by ID from the privx local user store`,
-	Example: `
-privx-cli users trusted-clients client [access flags] --id TRUSTED-CLIENT-ID
-	`,
-	SilenceUsage: true,
-	RunE:         trustedClient,
-}
-
-func trustedClient(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	trustedClient, err := store.TrustedClient(trustedClientID)
-	if err != nil {
-		return err
-	}
-
-	return stdout(trustedClient)
-}
-
-//
-//
-var deleteTrustedClientCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "delete trusted client",
-	Long:  `delete a trusted client from the privx local user store`,
-	Example: `
-privx-cli users local trusted-clients delete [access flags] --id TRUSTED-CLIENT-ID
-	`,
-	SilenceUsage: true,
-	RunE:         deleteTrustedClient,
-}
-
-func deleteTrustedClient(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	err := store.DeleteTrustedClient(trustedClientID)
-
-	return err
-}
-
-//
-//
-var updateTrustedClientCmd = &cobra.Command{
-	Use:   "update",
-	Short: "update trusted client",
-	Long:  `update an existing trusted client inside the privx local user store`,
-	Example: `
-privx-cli users local trusted-clients update [access flags] --id TRUSTED-CLIENT-ID JSON-FILE
-	`,
-	SilenceUsage: true,
-	RunE:         updateTrustedClient,
-}
-
-func updateTrustedClient(cmd *cobra.Command, args []string) error {
-	var trustedClient userstore.TrustedClient
-	api := userstore.New(curl())
-
-	if len(args) != 1 {
-		return errors.New("requires json file as argument")
-	}
-
-	file, err := openJSON(args[0])
-	if err != nil {
-		return err
-	}
-
-	jsonParser := json.NewDecoder(file)
-	err = jsonParser.Decode(&trustedClient)
-	if err != nil {
-		return errors.New("json file decoding failed")
-	}
-
-	err = api.UpdateTrustedClient(trustedClientID, &trustedClient)
-
-	return err
-}
-
-//
-//
-var extenderClientsCmd = &cobra.Command{
-	Use:   "extender-clients",
-	Short: "get extender clients",
-	Long:  `get extender clients from the privx local user store`,
-	Example: `
-privx-cli users local extender-clients [access flags]
-	`,
-	SilenceUsage: true,
-	RunE:         extenderClients,
-}
-
-func extenderClients(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	extenderClients, err := store.TrustedClients()
-	if err != nil {
-		return err
-	}
-
-	return stdout(extenderClients)
-}
-
-//
-//
-var apiClientsCmd = &cobra.Command{
-	Use:   "api-clients",
-	Short: "get API clients",
-	Long:  `get all API clients from the privx local user store`,
-	Example: `
-privx-cli users local api-clients [access flags]
-	`,
-	SilenceUsage: true,
-	RunE:         apiClients,
-}
-
-func apiClients(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-	result, err := store.APIClients()
-	if err != nil {
-		return err
-	}
-
-	return stdout(result)
-}
-
-//
-//
-var createAPIClientCmd = &cobra.Command{
-	Use:   "create",
-	Short: "create new API client",
-	Long:  `create new API client to privX local user store`,
-	Example: `
-privx-cli users local api-clients create [access flags] --name NAME --roles ROLE-ID,ROLE-ID
-	`,
-	SilenceUsage: true,
-	RunE:         createAPIClient,
-}
-
-func createAPIClient(cmd *cobra.Command, args []string) error {
-	api := userstore.New(curl())
-
-	id, err := api.CreateAPIClient(name, strings.Split(apiClientRoles, ","))
-	if err != nil {
-		return err
-	}
-
-	return stdout(id)
-}
-
-//
-//
-var apiClientCmd = &cobra.Command{
-	Use:   "client",
-	Short: "get API client",
-	Long:  `get API client by ID from the privx local user store`,
-	Example: `
-privx-cli users local api-clients client [access flags] --id API-CLIENT-ID
-	`,
-	SilenceUsage: true,
-	RunE:         apiClient,
-}
-
-func apiClient(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	result, err := store.APIClient(clientID)
-	if err != nil {
-		return err
-	}
-
-	return stdout(result)
-}
-
-//
-//
-var deleteAPIClientCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "delete API client",
-	Long:  `delete a API client from the privx local user store`,
-	Example: `
-privx-cli users local api-clients delete [access flags] --id API-CLIENT-ID
-	`,
-	SilenceUsage: true,
-	RunE:         deleteAPIClient,
-}
-
-func deleteAPIClient(cmd *cobra.Command, args []string) error {
-	store := userstore.New(curl())
-
-	err := store.DeleteAPIClient(clientID)
-
-	return err
-}
-
-//
-//
-var updateAPIClientCmd = &cobra.Command{
-	Use:   "update",
-	Short: "update API client",
-	Long:  `update an existing API client inside the privx local user store`,
-	Example: `
-privx-cli users local api-clients update [access flags] --id API-CLIENT-ID JSON-FILE
-	`,
-	SilenceUsage: true,
-	RunE:         updateAPIClient,
-}
-
-func updateAPIClient(cmd *cobra.Command, args []string) error {
-	var apiClient userstore.APIClient
-	api := userstore.New(curl())
-
-	if len(args) != 1 {
-		return errors.New("requires json file as argument")
-	}
-
-	file, err := openJSON(args[0])
-	if err != nil {
-		return err
-	}
-
-	jsonParser := json.NewDecoder(file)
-	err = jsonParser.Decode(&apiClient)
-	if err != nil {
-		return errors.New("json file decoding failed")
-	}
-
-	err = api.UpdateAPIClient(clientID, &apiClient)
-
-	return err
-}
-
-//
-//
-var usersCmd = &cobra.Command{
+var userListCmd = &cobra.Command{
 	Use:   "users",
 	Short: "PrivX users",
 	Long:  `List and manage PrivX users`,
@@ -635,10 +194,10 @@ var usersCmd = &cobra.Command{
 privx-cli users [access flags]
 	`,
 	SilenceUsage: true,
-	RunE:         users,
+	RunE:         userList,
 }
 
-func users(cmd *cobra.Command, args []string) error {
+func userList(cmd *cobra.Command, args []string) error {
 	store := rolestore.New(curl())
 	users, err := store.SearchUsers(strings.Join(userQuery, ","), "")
 	if err != nil {
@@ -650,18 +209,18 @@ func users(cmd *cobra.Command, args []string) error {
 
 //
 //
-var usersInfoCmd = &cobra.Command{
-	Use:   "info",
+var userShowCmd = &cobra.Command{
+	Use:   "show",
 	Short: "Description about PrivX user",
 	Long:  `Description about PrivX user`,
 	Example: `
-privx-cli users info [access flags] UID ...
+privx-cli users show [access flags] UID ...
 	`,
 	SilenceUsage: true,
-	RunE:         info,
+	RunE:         userShow,
 }
 
-func info(cmd *cobra.Command, args []string) error {
+func userShow(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("requires at least one user id as argument")
 	}

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/SSHcom/privx-sdk-go/api/rolestore"
+	"github.com/SSHcom/privx-sdk-go/api/userstore"
 	"github.com/spf13/cobra"
 )
 
@@ -47,8 +48,6 @@ func init() {
 	userUpdatePasswordCmd.MarkFlagRequired("uid")
 	userUpdatePasswordCmd.MarkFlagRequired("password")
 
-	//
-	// users commands
 	userListCmd.AddCommand(userShowCmd)
 
 	userListCmd.AddCommand(usersRolesCmd)

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -273,5 +273,5 @@ func readJSON(name string, object interface{}) error {
 		return err
 	}
 
-	return err
+	return nil
 }

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -66,6 +66,7 @@ var userCreateCmd = &cobra.Command{
 	Example: `
 privx-cli users create [access flags] JSON-FILE
 	`,
+	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE:         userCreate,
 }
@@ -73,10 +74,6 @@ privx-cli users create [access flags] JSON-FILE
 func userCreate(cmd *cobra.Command, args []string) error {
 	var newUser userstore.LocalUser
 	api := userstore.New(curl())
-
-	if len(args) != 1 {
-		return errors.New("requires json file as argument")
-	}
 
 	file, err := openJSON(args[0])
 	if err != nil {
@@ -106,6 +103,7 @@ var userUpdateCmd = &cobra.Command{
 	Example: `
 privx-cli users update [access flags] JSON-FILE --uid UID
 	`,
+	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE:         userUpdate,
 }
@@ -113,10 +111,6 @@ privx-cli users update [access flags] JSON-FILE --uid UID
 func userUpdate(cmd *cobra.Command, args []string) error {
 	var updateUser userstore.LocalUser
 	api := userstore.New(curl())
-
-	if len(args) != 1 {
-		return errors.New("requires json file as argument")
-	}
 
 	file, err := openJSON(args[0])
 	if err != nil {
@@ -214,15 +208,12 @@ var userShowCmd = &cobra.Command{
 	Example: `
 privx-cli users show [access flags] UID ...
 	`,
+	Args:         cobra.MinimumNArgs(1),
 	SilenceUsage: true,
 	RunE:         userShow,
 }
 
 func userShow(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return errors.New("requires at least one user id as argument")
-	}
-
 	store := rolestore.New(curl())
 	users := []rolestore.User{}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/SSHcom/privx-cli
 go 1.14
 
 require (
-	github.com/SSHcom/privx-sdk-go
-	github.com/spf13/cobra v1.1.1
+	github.com/SSHcom/privx-sdk-go v0.4.0
+	github.com/spf13/cobra v1.1.3
 )

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/SSHcom/privx-sdk-go v0.2.0 h1:ieKUKjDQo7lnGOjNabEupOsb/YxCZUvYcyNzvrpjIx4=
-github.com/SSHcom/privx-sdk-go v0.2.0/go.mod h1:MBMEtcBvvHCCOWZC4udSCJzW78sG90kmqBtB22Fr9gg=
-github.com/SSHcom/privx-sdk-go v0.3.0 h1:9uMHcGou1m71kBHotePcOr63h3knFGwTzkEW9wWJz8c=
-github.com/SSHcom/privx-sdk-go v0.3.0/go.mod h1:MBMEtcBvvHCCOWZC4udSCJzW78sG90kmqBtB22Fr9gg=
-github.com/SSHcom/privx-sdk-go v0.4.0 h1:3UxGbTbg3DZ0g3LisgxQb89FIUs+uB7avu0kDaYRqZs=
-github.com/SSHcom/privx-sdk-go v0.4.0/go.mod h1:MBMEtcBvvHCCOWZC4udSCJzW78sG90kmqBtB22Fr9gg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -43,6 +37,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -157,6 +153,8 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
+github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -287,6 +285,7 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Added new commands to the CLI to interact with the public PrivX local user store API's.

The following endpoints are covered - > https://privx.docs.ssh.com/reference#get_local-user-store-api-v1-users

