### PR TITLE
refactor: move local user related cmds to new file, rf existing cmds

### DIFF
--- a/cmd/apiclients.go
+++ b/cmd/apiclients.go
@@ -38,6 +38,11 @@ func apiClientListCmd() *cobra.Command {
 		RunE:         apiClientList,
 	}
 
+	cmd.AddCommand(apiClientCreateCmd())
+	cmd.AddCommand(apiClientShowCmd())
+	cmd.AddCommand(apiClientDeleteCmd())
+	cmd.AddCommand(apiClientUpdateCmd())
+
 	return cmd
 }
 
@@ -48,11 +53,6 @@ func apiClientList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	cmd.AddCommand(apiClientCreateCmd())
-	cmd.AddCommand(apiClientShowCmd())
-	cmd.AddCommand(apiClientDeleteCmd())
-	cmd.AddCommand(apiClientUpdateCmd())
 
 	return stdout(clients)
 }

--- a/cmd/clients.go
+++ b/cmd/clients.go
@@ -7,71 +7,77 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/SSHcom/privx-sdk-go/api/userstore"
 	"github.com/spf13/cobra"
 )
 
-var (
+type clientOptions struct {
 	trustedClientID string
-)
+}
 
 func init() {
-	rootCmd.AddCommand(clientListCmd)
-
-	clientListCmd.AddCommand(clientCreateCmd)
-
-	clientListCmd.AddCommand(clientShowCmd)
-	clientShowCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
-	clientShowCmd.MarkFlagRequired("id")
-
-	clientListCmd.AddCommand(clientDeleteCmd)
-	clientDeleteCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
-	clientDeleteCmd.MarkFlagRequired("id")
-
-	clientListCmd.AddCommand(clientUpdateCmd)
-	clientUpdateCmd.Flags().StringVar(&trustedClientID, "id", "", "unique trusted client id")
-	clientUpdateCmd.MarkFlagRequired("id")
+	rootCmd.AddCommand(clientListCmd())
 }
 
 //
 //
-var clientListCmd = &cobra.Command{
-	Use:   "clients",
-	Short: "Get trusted clients",
-	Long:  `Get trusted clients`,
-	Example: `
-privx-cli clients [access flags]
-	`,
-	SilenceUsage: true,
-	RunE:         trustedClients,
+func clientListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clients",
+		Short: "Get trusted clients",
+		Long:  `Get trusted clients`,
+		Example: `
+	privx-cli clients [access flags]
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return trustedClients()
+		},
+	}
+
+	cmd.AddCommand(clientCreateCmd())
+	cmd.AddCommand(clientShowCmd())
+	cmd.AddCommand(clientDeleteCmd())
+	cmd.AddCommand(clientUpdateCmd())
+
+	return cmd
 }
 
-func trustedClients(cmd *cobra.Command, args []string) error {
+func trustedClients() error {
 	api := userstore.New(curl())
 
-	trustedClients, err := api.TrustedClients()
+	clients, err := api.TrustedClients()
 	if err != nil {
 		return err
 	}
 
-	return stdout(trustedClients)
+	return stdout(clients)
 }
 
 //
 //
-var clientCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create new trusted-client",
-	Long:  `Create new trusted client`,
-	Example: `
-privx-cli clients create [access flags] JSON-FILE
-	`,
-	Args:         cobra.ExactArgs(1),
-	SilenceUsage: true,
-	RunE:         clientCreate,
+func clientCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create new trusted-client",
+		Long:  `Create new trusted client`,
+		Example: `
+	privx-cli clients create [access flags] JSON-FILE
+		`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return clientCreate(args)
+		},
+	}
+
+	return cmd
 }
 
-func clientCreate(cmd *cobra.Command, args []string) error {
+func clientCreate(args []string) error {
 	var trustedClient userstore.TrustedClient
 	api := userstore.New(curl())
 
@@ -90,64 +96,111 @@ func clientCreate(cmd *cobra.Command, args []string) error {
 
 //
 //
-var clientShowCmd = &cobra.Command{
-	Use:   "show",
-	Short: "Get trusted client by ID",
-	Long:  `Get trusted client by ID`,
-	Example: `
-privx-cli clients show [access flags] --id TRUSTED-CLIENT-ID
-	`,
-	SilenceUsage: true,
-	RunE:         clientShow,
-}
+func clientShowCmd() *cobra.Command {
+	options := clientOptions{}
 
-func clientShow(cmd *cobra.Command, args []string) error {
-	api := userstore.New(curl())
-
-	trustedClient, err := api.TrustedClient(trustedClientID)
-	if err != nil {
-		return err
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Get trusted client by ID",
+		Long:  `Get trusted client by ID. Client ID's are separated by commas when using multiple values, see example`,
+		Example: `
+	privx-cli clients show [access flags] --id <TRUSTED-CLIENT-ID>,<TRUSTED-CLIENT-ID>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return clientShow(options)
+		},
 	}
 
-	return stdout(trustedClient)
+	flags := cmd.Flags()
+	flags.StringVar(&options.trustedClientID, "id", "", "trusted client ID")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
+}
+
+func clientShow(options clientOptions) error {
+	api := userstore.New(curl())
+	clients := []userstore.TrustedClient{}
+
+	for _, id := range strings.Split(options.trustedClientID, ",") {
+		client, err := api.TrustedClient(id)
+		if err != nil {
+			return err
+		}
+		clients = append(clients, *client)
+	}
+
+	return stdout(clients)
 }
 
 //
 //
-var clientDeleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete trusted client",
-	Long:  `Delete a trusted client`,
-	Example: `
-privx-cli clients delete [access flags] --id TRUSTED-CLIENT-ID
-	`,
-	SilenceUsage: true,
-	RunE:         clientDelete,
+func clientDeleteCmd() *cobra.Command {
+	options := clientOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete trusted client",
+		Long:  `Delete trusted client. Client ID's are separated by commas when using multiple values, see example`,
+		Example: `
+	privx-cli clients delete [access flags] --id <TRUSTED-CLIENT-ID>,<TRUSTED-CLIENT-ID>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return clientDelete(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.trustedClientID, "id", "", "trusted client ID")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
 }
 
-func clientDelete(cmd *cobra.Command, args []string) error {
+func clientDelete(options clientOptions) error {
 	api := userstore.New(curl())
 
-	err := api.DeleteTrustedClient(trustedClientID)
+	for _, id := range strings.Split(options.trustedClientID, ",") {
+		err := api.DeleteTrustedClient(id)
+		if err != nil {
+			return err
+		} else {
+			fmt.Println(id)
+		}
+	}
 
-	return err
+	return nil
 }
 
 //
 //
-var clientUpdateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Update trusted client",
-	Long:  `Update an existing trusted client`,
-	Example: `
-privx-cli clients update [access flags] --id TRUSTED-CLIENT-ID JSON-FILE
-	`,
-	Args:         cobra.ExactArgs(1),
-	SilenceUsage: true,
-	RunE:         clientUpdate,
+func clientUpdateCmd() *cobra.Command {
+	options := clientOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update trusted client",
+		Long:  `Update trusted client`,
+		Example: `
+	privx-cli clients update [access flags] --id <TRUSTED-CLIENT-ID> JSON-FILE
+		`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return clientUpdate(options, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.trustedClientID, "id", "", "trusted client ID")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
 }
 
-func clientUpdate(cmd *cobra.Command, args []string) error {
+func clientUpdate(options clientOptions, args []string) error {
 	var trustedClient userstore.TrustedClient
 	api := userstore.New(curl())
 
@@ -156,7 +209,10 @@ func clientUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = api.UpdateTrustedClient(trustedClientID, &trustedClient)
+	err = api.UpdateTrustedClient(options.trustedClientID, &trustedClient)
+	if err != nil {
+		return err
+	}
 
-	return err
+	return nil
 }

--- a/cmd/localusers.go
+++ b/cmd/localusers.go
@@ -1,0 +1,274 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/SSHcom/privx-sdk-go/api/userstore"
+	"github.com/spf13/cobra"
+)
+
+type localUserOptions struct {
+	userID   string
+	userName string
+	password string
+	offset   int
+	limit    int
+}
+
+func init() {
+	rootCmd.AddCommand(localUserListCmd())
+}
+
+//
+//
+func localUserListCmd() *cobra.Command {
+	options := localUserOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "local-users",
+		Short: "List and manage local users",
+		Long:  `List and manage local users`,
+		Example: `
+	privx-cli local-users [access flags]
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return localUserList(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.IntVar(&options.offset, "offset", 0, "where to start fetching the items")
+	flags.IntVar(&options.limit, "limit", 50, "number of items to return")
+	flags.StringVar(&options.userName, "name", "", "username of the user")
+	flags.StringVar(&options.userID, "id", "", "ID of the user")
+
+	cmd.AddCommand(localUserShowCmd())
+	cmd.AddCommand(localUserCreateCmd())
+	cmd.AddCommand(localUserUpdateCmd())
+	cmd.AddCommand(localUserDeleteCmd())
+	cmd.AddCommand(localUserUpdatePasswordCmd())
+
+	return cmd
+}
+
+func localUserList(options localUserOptions) error {
+	api := userstore.New(curl())
+
+	users, err := api.LocalUsers(options.offset, options.limit,
+		options.userID, options.userName)
+	if err != nil {
+		return err
+	}
+
+	return stdout(users)
+}
+
+//
+//
+func localUserShowCmd() *cobra.Command {
+	options := localUserOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Get local user by ID",
+		Long:  `Get local user by ID. User ID's are separated by commas when using multiple values, see example`,
+		Example: `
+	privx-cli local-users show [access flags] --id <USER-ID>,<USER-ID>
+		`,
+		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return localUserShow(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.userID, "id", "", "user ID")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
+}
+
+func localUserShow(options localUserOptions) error {
+	api := userstore.New(curl())
+	users := []userstore.LocalUser{}
+
+	for _, id := range strings.Split(options.userID, ",") {
+		user, err := api.LocalUser(id)
+		if err != nil {
+			return err
+		}
+		users = append(users, *user)
+	}
+
+	return stdout(users)
+}
+
+//
+//
+func localUserCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create new local user",
+		Long:  `Create new local user`,
+		Example: `
+	privx-cli local-users create [access flags] JSON-FILE
+		`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return localUserCreate(args)
+		},
+	}
+
+	return cmd
+}
+
+func localUserCreate(args []string) error {
+	var newUser userstore.LocalUser
+	api := userstore.New(curl())
+
+	err := decodeJSON(args[0], &newUser)
+	if err != nil {
+		return err
+	}
+
+	uid, err := api.CreateLocalUser(newUser)
+	if err != nil {
+		return err
+	}
+
+	return stdout(uid)
+}
+
+//
+//
+func localUserUpdateCmd() *cobra.Command {
+	options := localUserOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update local user",
+		Long:  `Update local user`,
+		Example: `
+	privx-cli local-users update [access flags] JSON-FILE --id <USER-ID>
+		`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return localUserUpdate(options, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.userID, "id", "", "unique user ID")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
+}
+
+func localUserUpdate(options localUserOptions, args []string) error {
+	var updateUser userstore.LocalUser
+	api := userstore.New(curl())
+
+	err := decodeJSON(args[0], &updateUser)
+	if err != nil {
+		return err
+	}
+
+	err = api.UpdateLocalUser(options.userID, &updateUser)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//
+//
+func localUserDeleteCmd() *cobra.Command {
+	options := localUserOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete local user",
+		Long:  `Delete local user. User ID's are separated by commas when using multiple values, see example`,
+		Example: `
+	privx-cli local-users delete [access flags] --id <USER-ID>,<USER-ID>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return localUserDelete(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.userID, "id", "", "unique user ID")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
+}
+
+func localUserDelete(options localUserOptions) error {
+	api := userstore.New(curl())
+
+	for _, id := range strings.Split(options.userID, ",") {
+		err := api.DeleteLocalUser(id)
+		if err != nil {
+			return err
+		} else {
+			fmt.Println(id)
+		}
+	}
+
+	return nil
+}
+
+//
+//
+func localUserUpdatePasswordCmd() *cobra.Command {
+	options := localUserOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "update-password",
+		Short: "Update local user password",
+		Long:  `Update local user password`,
+		Example: `
+	privx-cli local-users update-password [access flags] --id <USER-ID> --password <NEW-PASSWORD>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return localUserUpdatePassword(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&userID, "id", "", "unique user id")
+	flags.StringVar(&password, "password", "", "new password for local user")
+	cmd.MarkFlagRequired("id")
+	cmd.MarkFlagRequired("password")
+
+	return cmd
+}
+
+func localUserUpdatePassword(options localUserOptions) error {
+	newPassword := userstore.Password{
+		Password: options.password,
+	}
+	api := userstore.New(curl())
+
+	err := api.UpdateLocalUserPassword(options.userID, &newPassword)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/SSHcom/privx-sdk-go/api/rolestore"
-	"github.com/SSHcom/privx-sdk-go/api/userstore"
 	"github.com/spf13/cobra"
 )
 
@@ -32,22 +31,6 @@ func init() {
 	rootCmd.AddCommand(userListCmd)
 	userListCmd.Flags().StringArrayVarP(&userQuery, "query", "q", []string{}, "query PrivX users with keyword")
 
-	userListCmd.AddCommand(userCreateCmd)
-
-	userListCmd.AddCommand(userUpdateCmd)
-	userUpdateCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
-	userUpdateCmd.MarkFlagRequired("uid")
-
-	userListCmd.AddCommand(userDeleteCmd)
-	userDeleteCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
-	userDeleteCmd.MarkFlagRequired("uid")
-
-	userListCmd.AddCommand(userUpdatePasswordCmd)
-	userUpdatePasswordCmd.Flags().StringVar(&userID, "uid", "", "unique user id")
-	userUpdatePasswordCmd.Flags().StringVar(&password, "password", "", "new password for local user")
-	userUpdatePasswordCmd.MarkFlagRequired("uid")
-	userUpdatePasswordCmd.MarkFlagRequired("password")
-
 	userListCmd.AddCommand(userShowCmd)
 
 	userListCmd.AddCommand(usersRolesCmd)
@@ -55,113 +38,6 @@ func init() {
 	usersRolesCmd.Flags().StringArrayVar(&userRoleGrant, "grant", []string{}, "grant role to user, requires role unique id.")
 	usersRolesCmd.Flags().StringArrayVar(&userRoleRevoke, "revoke", []string{}, "revoke role from user, requires role unique id.")
 	usersRolesCmd.MarkFlagRequired("uid")
-}
-
-//
-//
-var userCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create new local user",
-	Long:  `Create new local user`,
-	Example: `
-privx-cli users create [access flags] JSON-FILE
-	`,
-	Args:         cobra.ExactArgs(1),
-	SilenceUsage: true,
-	RunE:         userCreate,
-}
-
-func userCreate(cmd *cobra.Command, args []string) error {
-	var newUser userstore.LocalUser
-	api := userstore.New(curl())
-
-	err := decodeJSON(args[0], &newUser)
-	if err != nil {
-		return err
-	}
-
-	uid, err := api.CreateLocalUser(newUser)
-	if err != nil {
-		return err
-	}
-
-	return stdout(uid)
-}
-
-//
-//
-var userUpdateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Update local user",
-	Long:  `Update a local user`,
-	Example: `
-privx-cli users update [access flags] JSON-FILE --uid UID
-	`,
-	Args:         cobra.ExactArgs(1),
-	SilenceUsage: true,
-	RunE:         userUpdate,
-}
-
-func userUpdate(cmd *cobra.Command, args []string) error {
-	var updateUser userstore.LocalUser
-	api := userstore.New(curl())
-
-	err := decodeJSON(args[0], &updateUser)
-	if err != nil {
-		return err
-	}
-
-	err = api.UpdateLocalUser(userID, &updateUser)
-	if err != nil {
-		return err
-	}
-
-	return err
-}
-
-//
-//
-var userDeleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete local user",
-	Long:  `Delete a local user`,
-	Example: `
-privx-cli users delete [access flags] --uid UID
-	`,
-	SilenceUsage: true,
-	RunE:         userDelete,
-}
-
-func userDelete(cmd *cobra.Command, args []string) error {
-	api := userstore.New(curl())
-
-	err := api.DeleteLocalUser(userID)
-
-	return err
-}
-
-//
-//
-var userUpdatePasswordCmd = &cobra.Command{
-	Use:   "update-password",
-	Short: "Update local user password",
-	Long:  `Update a local users password`,
-	Example: `
-privx-cli users update-password [access flags] --uid UID --password NEW-PASSWORD
-	`,
-	SilenceUsage: true,
-	RunE:         userUpdatePassword,
-}
-
-func userUpdatePassword(cmd *cobra.Command, args []string) error {
-	newPassword := userstore.Password{
-		Password: password,
-	}
-	api := userstore.New(curl())
-
-	err := api.UpdateLocalUserPassword(userID, &newPassword)
-
-	return err
 }
 
 //


### PR DESCRIPTION
Moved exsting local user commands to a new file to keep them separated from the role store related commands.
Refactored the cmds layout.