### PR TITLE
feat(CLI): add new authorizer commands

### DIFF
--- a/cmd/accessgroups.go
+++ b/cmd/accessgroups.go
@@ -1,0 +1,239 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/SSHcom/privx-sdk-go/api/authorizer"
+	"github.com/spf13/cobra"
+)
+
+type accessGroupOptions struct {
+	accessGroupID string
+	sortkey       string
+	sortdir       string
+	offset        int
+	limit         int
+}
+
+func (m accessGroupOptions) normalize_sortdir() string {
+	return strings.ToUpper(m.sortdir)
+}
+
+func init() {
+	rootCmd.AddCommand(accessGroupListCmd())
+}
+
+//
+//
+func accessGroupListCmd() *cobra.Command {
+	options := accessGroupOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "access-groups",
+		Short: "List and manage access groups",
+		Long:  `List and manage access groups`,
+		Example: `
+	privx-cli access-groups [access flags] --limit <LIMIT> --offset <OFFSET>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return accessGroupList(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.IntVar(&options.offset, "offset", 0, "where to start fetching the items")
+	flags.IntVar(&options.limit, "limit", 50, "number of items to return")
+	flags.StringVar(&options.sortkey, "sortkey", "", "sort by specific object property")
+	flags.StringVar(&options.sortdir, "sortdir", "", "sort direction, ASC or DESC")
+
+	cmd.AddCommand(accessGroupCreateCmd())
+	cmd.AddCommand(accessGroupSearchCmd())
+	cmd.AddCommand(accessGroupShowCmd())
+	cmd.AddCommand(accessGroupUpdateCmd())
+
+	return cmd
+}
+
+func accessGroupList(options accessGroupOptions) error {
+	api := authorizer.New(curl())
+
+	groups, err := api.AccessGroups(options.offset, options.limit,
+		options.sortkey, options.normalize_sortdir())
+	if err != nil {
+		return err
+	}
+
+	return stdout(groups)
+}
+
+//
+//
+func accessGroupCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create access group",
+		Long:  `Create access group`,
+		Example: `
+	privx-cli access-groups create [access flags] JSON-FILE
+		`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return accessGroupCreate(cmd, args)
+		},
+	}
+
+	return cmd
+}
+
+func accessGroupCreate(cmd *cobra.Command, args []string) error {
+	var newAccessGroup authorizer.AccessGroup
+	api := authorizer.New(curl())
+
+	err := decodeJSON(args[0], &newAccessGroup)
+	if err != nil {
+		return err
+	}
+
+	id, err := api.CreateAccessGroup(&newAccessGroup)
+	if err != nil {
+		return err
+	}
+
+	return stdout(id)
+}
+
+//
+//
+func accessGroupSearchCmd() *cobra.Command {
+	options := accessGroupOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search access groups",
+		Long:  `Search access groups`,
+		Example: `
+	privx-cli access-groups search [access flags] --offset <OFFSET> --sortkey <SORTKEY>
+	privx-cli access-groups search [access flags] --limit <LIMIT> JSON-FILE
+		`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return accessGroupSearch(options, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.IntVar(&options.offset, "offset", 0, "where to start fetching the items")
+	flags.IntVar(&options.limit, "limit", 50, "number of items to return")
+	flags.StringVar(&options.sortkey, "sortkey", "", "sort by specific object property")
+	flags.StringVar(&options.sortdir, "sortdir", "", "sort direction, ASC or DESC")
+
+	return cmd
+}
+
+func accessGroupSearch(options accessGroupOptions, args []string) error {
+	var searchObject authorizer.SearchParams
+	api := authorizer.New(curl())
+
+	if len(args) == 1 {
+		err := decodeJSON(args[0], &searchObject)
+		if err != nil {
+			return err
+		}
+	}
+
+	hosts, err := api.SearchAccessGroup(options.offset, options.limit, options.sortkey,
+		options.normalize_sortdir(), &searchObject)
+	if err != nil {
+		return err
+	}
+
+	return stdout(hosts)
+}
+
+//
+//
+func accessGroupShowCmd() *cobra.Command {
+	options := accessGroupOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Get access group by ID",
+		Long:  `Get access group by ID. Access group ID's are separated by commas when using multiple values, see example`,
+		Example: `
+	privx-cli access-groups show [access flags] --id <ACCESS-GROUP-ID>,<ACCESS-GROUP-ID>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return accessGroupShow(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.accessGroupID, "id", "", "access group ID")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
+}
+
+func accessGroupShow(options accessGroupOptions) error {
+	api := authorizer.New(curl())
+
+	group, err := api.AccessGroup(options.accessGroupID)
+	if err != nil {
+		return err
+	}
+
+	return stdout(group)
+}
+
+//
+//
+func accessGroupUpdateCmd() *cobra.Command {
+	options := accessGroupOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update access group",
+		Long:  `Update access group`,
+		Example: `
+	privx-cli access-groups update [access flags] JSON-FILE --id <ACCESS-GROUP-ID>
+		`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return accessGroupUpdate(options, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.accessGroupID, "id", "", "access group ID")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
+}
+
+func accessGroupUpdate(options accessGroupOptions, args []string) error {
+	var updateAccessGroup authorizer.AccessGroup
+	api := authorizer.New(curl())
+
+	err := decodeJSON(args[0], &updateAccessGroup)
+	if err != nil {
+		return err
+	}
+
+	err = api.UpdateAccessGroup(options.accessGroupID, &updateAccessGroup)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/authorizer.go
+++ b/cmd/authorizer.go
@@ -1,0 +1,378 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/SSHcom/privx-sdk-go/api/authorizer"
+	"github.com/spf13/cobra"
+)
+
+type authorizerOptions struct {
+	accessGroupID   string
+	caID            string
+	fileName        string
+	trustedClientID string
+	sortkey         string
+	sortdir         string
+	limit           int
+	offset          int
+}
+
+func init() {
+	rootCmd.AddCommand(authorizerListCmd())
+}
+
+func (m authorizerOptions) normalize_sortdir() string {
+	return strings.ToUpper(m.sortdir)
+}
+
+//
+//
+func authorizerListCmd() *cobra.Command {
+	options := authorizerOptions{}
+
+	cmd := &cobra.Command{
+		Use:          "authorizer",
+		Short:        "List and manage authorizer root certificates",
+		Long:         `List and manage authorizer root certificates`,
+		SilenceUsage: true,
+		Example: `
+	privx-cli authorizer [access flags]
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return authorizerList(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.accessGroupID, "access-group-id", "", "access group ID filter")
+
+	cmd.AddCommand(authorizerShowCmd())
+	cmd.AddCommand(authorizerRevocationListCmd())
+	cmd.AddCommand(targetHostCredentialShowCmd())
+	cmd.AddCommand(deploymentScriptDownloadCmd())
+	cmd.AddCommand(principalCommandScriptDownloadCmd())
+	cmd.AddCommand(sslTrustAnchorShowCmd())
+	cmd.AddCommand(extenderTrustAnchorShowCmd())
+	cmd.AddCommand(certificateSearchCmd())
+
+	return cmd
+}
+
+func authorizerList(options authorizerOptions) error {
+	api := authorizer.New(curl())
+
+	certificates, err := api.CACertificates(options.accessGroupID)
+	if err != nil {
+		return err
+	}
+
+	return stdout(certificates)
+}
+
+//
+//
+func authorizerShowCmd() *cobra.Command {
+	options := authorizerOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Get authorizer's root certificate",
+		Long:  `Get authorizer's root certificate`,
+		Example: `
+	privx-cli authorizer show [access flags] --id <CA-ID> --name <FILE-NAME>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return authorizerShow(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.caID, "id", "", "ca ID")
+	flags.StringVar(&options.fileName, "name", "", "file name")
+	cmd.MarkFlagRequired("id")
+	cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func authorizerShow(options authorizerOptions) error {
+	api := authorizer.New(curl())
+
+	err := api.CACertificate(options.caID, options.fileName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//
+//
+func authorizerRevocationListCmd() *cobra.Command {
+	options := authorizerOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "show-crl",
+		Short: "Get authorizer CA's certificate revocation list",
+		Long:  `Get authorizer CA's certificate revocation list`,
+		Example: `
+	privx-cli authorizer revocation-list [access flags] --id <CA-ID> --name <FILE-NAME>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return authorizerRevocationList(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.caID, "id", "", "ca ID")
+	flags.StringVar(&options.fileName, "name", "", "file name")
+	cmd.MarkFlagRequired("id")
+	cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func authorizerRevocationList(options authorizerOptions) error {
+	api := authorizer.New(curl())
+
+	err := api.CertificateRevocationList(options.caID, options.fileName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//
+//
+func targetHostCredentialShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "target-host-credentials",
+		Short: "Get target host credentials for the user",
+		Long:  `Get target host credentials for the user`,
+		Example: `
+	privx-cli authorizer target-host-credentials [access flags] JSON-FILE
+		`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return targetHostCredential(args)
+		},
+	}
+
+	return cmd
+}
+
+func targetHostCredential(args []string) error {
+	var authorizationRequest authorizer.AuthorizationRequest
+	api := authorizer.New(curl())
+
+	err := decodeJSON(args[0], &authorizationRequest)
+	if err != nil {
+		return err
+	}
+
+	certificate, err := api.TargetHostCredentials(&authorizationRequest)
+	if err != nil {
+		return err
+	}
+
+	return stdout(certificate)
+}
+
+//
+//
+func deploymentScriptDownloadCmd() *cobra.Command {
+	options := authorizerOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "deployment-script",
+		Short: "Get deployment script pre-configured for PrivX installation",
+		Long:  `Get deployment script pre-configured for PrivX installation`,
+		Example: `
+	privx-cli authorizer deployment-script [access flags] --trusted-client-id <TRUSTED-CLIENT-ID> --name <FILE-NAME>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentScriptDownload(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.trustedClientID, "trusted-client-id", "", "trusted client ID")
+	flags.StringVar(&options.fileName, "name", "", "file name")
+	cmd.MarkFlagRequired("trusted-client-id")
+	cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func deploymentScriptDownload(options authorizerOptions) error {
+	api := authorizer.New(curl())
+
+	handler, err := api.DeployScriptDownloadHandle(options.trustedClientID)
+	if err != nil {
+		return err
+	}
+
+	err = api.DownloadDeployScript(options.trustedClientID, handler.SessionID, options.fileName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//
+//
+func principalCommandScriptDownloadCmd() *cobra.Command {
+	options := authorizerOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "principal-cmd-script",
+		Short: "Get the principals command script",
+		Long:  `Get the principals command script`,
+		Example: `
+	privx-cli authorizer principal-cmd-script [access flags] --name <FILE-NAME>
+		`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return principalCommandScriptDownload(options)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.fileName, "name", "", "file name")
+	cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func principalCommandScriptDownload(options authorizerOptions) error {
+	api := authorizer.New(curl())
+
+	err := api.DownloadPrincipalCommandScript(options.fileName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//
+//
+func sslTrustAnchorShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "ssl-trust-anchor",
+		Short:        "Get the SSL trust anchor",
+		Long:         `Get the SSL trust anchor`,
+		SilenceUsage: true,
+		Example: `
+	privx-cli authorizer ssl-trust-anchor [access flags]
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return sslTrustAnchorShow()
+		},
+	}
+
+	return cmd
+}
+
+func sslTrustAnchorShow() error {
+	api := authorizer.New(curl())
+
+	anchor, err := api.SSLTrustAnchor()
+	if err != nil {
+		return err
+	}
+
+	return stdout(anchor)
+}
+
+//
+//
+func extenderTrustAnchorShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "extender-trust-anchor",
+		Short:        "Get the extender trust anchor",
+		Long:         `Get the extender trust anchor`,
+		SilenceUsage: true,
+		Example: `
+	privx-cli authorizer extender-trust-anchor [access flags]
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return extenderTrustAnchorShow()
+		},
+	}
+
+	return cmd
+}
+
+func extenderTrustAnchorShow() error {
+	api := authorizer.New(curl())
+
+	anchor, err := api.ExtenderTrustAnchor()
+	if err != nil {
+		return err
+	}
+
+	return stdout(anchor)
+}
+
+//
+//
+func certificateSearchCmd() *cobra.Command {
+	options := authorizerOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search certificates",
+		Long:  `Search certificates`,
+		Example: `
+	privx-cli authorizer search [access flags] --offset <OFFSET> --sortkey <SORTKEY>
+	privx-cli authorizer search [access flags] --limit <LIMIT> JSON-FILE
+		`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return certificateSearch(options, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.IntVar(&options.offset, "offset", 0, "where to start fetching the items")
+	flags.IntVar(&options.limit, "limit", 50, "number of items to return")
+	flags.StringVar(&options.sortkey, "sortkey", "", "sort by specific object property")
+	flags.StringVar(&options.sortdir, "sortdir", "", "sort direction, ASC or DESC")
+
+	return cmd
+}
+
+func certificateSearch(options authorizerOptions, args []string) error {
+	var searchObject authorizer.APICertificateSearch
+	api := authorizer.New(curl())
+
+	if len(args) == 1 {
+		err := decodeJSON(args[0], &searchObject)
+		if err != nil {
+			return err
+		}
+	}
+
+	cert, err := api.SearchCert(options.offset, options.limit, options.sortkey,
+		options.normalize_sortdir(), &searchObject)
+	if err != nil {
+		return err
+	}
+
+	return stdout(cert)
+}


### PR DESCRIPTION
Added new authorizer commands to CLI.
The `authorizer` commands includes all the sub commands  for which I could not justify to create a new main command.
Gladly open for feedback and maybe some of them are even not needed inside the CLI.